### PR TITLE
Fixes xml:base and default namespace declarations

### DIFF
--- a/src/ontology/nomen.owl
+++ b/src/ontology/nomen.owl
@@ -10,8 +10,8 @@
 ]>
 
 
-<rdf:RDF xmlns="http://www.semanticweb.org/dmitriev/ontologies/2013/8/untitled-ontology-6#"
-     xml:base="http://www.semanticweb.org/dmitriev/ontologies/2013/8/untitled-ontology-6"
+<rdf:RDF xmlns="http://purl.obolibrary.org/obo/"
+     xml:base="http://purl.obolibrary.org/obo/"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:xsd="http://www.w3.org/2001/XMLSchema#"


### PR DESCRIPTION
The fact that these have presumably been left at initial (Protégé-suggested?) default settings happens to be inconsequential in the current version of the document, because all IRIs are given as absolute ones, and all XML elements use an explicit namespace, including the ones from this ontology.

That said, arguably they should be set to meaningful values, so that if in the future an ontology editor were to use a relative URI or a term from this ontology without namespace, then the presumably "correct  thing" would happen. For example, setting the default namespace (`xmlns`) correctly means you can write
```xml
<NOMEN_0000001>1960</NOMEN_0000001>
```
instead of
```
<obo:NOMEN_0000001>1960</obo:NOMEN_0000001>
```
and they would both result in the exact same axiom.

The other advantage is this change would eliminate a source of confusion as to what the namespace of this ontology is, see for example pensoft/OpenBiodiv#44.